### PR TITLE
Venmo API change to Textbelt Text 

### DIFF
--- a/Bill.py
+++ b/Bill.py
@@ -24,6 +24,12 @@ class Bill(object):
         self.date = date
         self.amount_to_be_charged = np.round(self.total * self.multiplier, 2)
 
+    def __str__(self):
+
+        info_string = f"{self.name} bill | {self.date.strftime('%Y-%m-%d')} | {self.amount_to_be_charged}"
+
+        return info_string
+
     def create_venmo_request(self, venmo_command):
 
         request_string = f"{self.name} bill - {self.date.strftime('%Y-%m-%d')}"

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from Bill import Bill, bills
 with open(".last_run_date.txt") as date_file:
     last_run_date = dt.strptime(date_file.readline().strip(), "%Y-%m-%d %H:%M:%S")
 
-with open('textbelt_api_key.txt') as key:
+with open('.textbelt_api_key.txt') as key:
     api_key = key.readline().strip()
 
 with open('output.log', 'w') as venmo_requests:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import requests
 from datetime import datetime as dt
 
 from EmailParser import EmailParser 
@@ -6,13 +7,13 @@ from Bill import Bill, bills
 with open(".last_run_date.txt") as date_file:
     last_run_date = dt.strptime(date_file.readline().strip(), "%Y-%m-%d %H:%M:%S")
 
-with open(".venmo_path.txt") as venmo_command_file:
-    venmo_command = venmo_command_file.readline().strip()
+with open('textbelt_api_key.txt') as key:
+    api_key = key.readline().strip()
 
-with open('venmo_requests_to_make.sh', 'w') as venmo_requests:
+with open('output.log', 'w') as venmo_requests:
 
-    venmo_requests.write("#!/bin/bash\n\n")
-
+    full_text_body = ""
+    full_charge_amount = 0
     for bill_name, bill_info in bills.items():
         parser = EmailParser(query = bill_info['query'],
                              search_string = bill_info['search_string'])
@@ -25,10 +26,18 @@ with open('venmo_requests_to_make.sh', 'w') as venmo_requests:
                             multiplier = bill_info['multiplier'],
                             chargee = bill_info['chargee'])
 
-                venmo_requests.write(bill.create_venmo_request(venmo_command))
+                full_text_body += str(bill) + "\n"
+                full_charge_amount += bill.amount_to_be_charged
+
+    full_text_body += f"\nTotal = {full_charge_amount}\n"
+
+    request_dict = {'phone': '3038106250', 'message': full_text_body, 'key': api_key}
+    resp = requests.post('https://textbelt.com/text/', request_dict)
+
+    log_info = resp.json()
 
 
 # should be last thing to execute
-with open(".last_run_date.txt", 'w') as date_file:
-    today = dt.strftime(dt.today(), "%Y-%m-%d %H:%M:%S")
-    date_file.write(str(today) + "\n")
+# with open(".last_run_date.txt", 'w') as date_file:
+#     today = dt.strftime(dt.today(), "%Y-%m-%d %H:%M:%S")
+#     date_file.write(str(today) + "\n")


### PR DESCRIPTION
Since the Venmo API is deprecated (and apparently has been for quite a while), I am moving away from using it. Instead,
I will be using [Textbelt](https://textbelt.com) to send myself a text of the charges to request. I emailed them (Textbelt) and they will re-charge my account when I have 0 texts left (this way I will only be charged for the texts I actually send).